### PR TITLE
feat: adjacency list for bonds

### DIFF
--- a/src/structures/molecule.cpp
+++ b/src/structures/molecule.cpp
@@ -73,17 +73,26 @@ int Molecule::degree(const Atom &atom) const {
     return sum;
 }
 
-
-std::vector<size_t> Molecule::get_bonded(size_t atom_idx) const {
+    
+void Molecule::precompute_bond_adjacency_lists() {
     const size_t n = atoms_->size();
-    std::vector<size_t> res;
-
-    for (size_t j = 0; j < n; j++) {
-        if (bond_info_[atom_idx * n + j]) {
-            res.push_back(static_cast<size_t>(j));
+    bond_adjacency_lists_.resize(n);
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < n; j++) {
+            if (bond_info_[i * n + j]) {
+                bond_adjacency_lists_[i].push_back(j);
+            }
         }
     }
-    return res;
+}
+
+
+const std::vector<size_t>& Molecule::get_bonded(size_t atom_idx) {
+    if (bond_adjacency_lists_.empty()) {
+        precompute_bond_adjacency_lists();
+    }
+
+    return bond_adjacency_lists_[atom_idx];
 }
 
 

--- a/src/structures/molecule.h
+++ b/src/structures/molecule.h
@@ -27,17 +27,20 @@ class Molecule {
     std::vector<int> max_hbo_{};
     std::vector<std::string> neighbour_elements_{};
     std::vector<char> bond_info_{};
+    std::vector<std::vector<size_t>> bond_adjacency_lists_{};
     std::vector<int> bond_distances_{};
     std::unique_ptr<kdtree_t> index_{nullptr};
     std::unique_ptr<AtomKDTreeAdaptor> adaptor_{nullptr};
 
-    [[nodiscard]] std::vector<size_t> get_bonded(size_t atom_idx) const;
+    [[nodiscard]] const std::vector<size_t>& get_bonded(size_t atom_idx);
 
     void init_bond_info();
 
     void init_bond_distances();
 
     void init_distance_tree();
+
+    void precompute_bond_adjacency_lists();
 
 public:
     [[nodiscard]] const std::vector<Atom> &atoms() const { return *atoms_; }


### PR DESCRIPTION
Performance improvement for `init_bond_distances`.

*Details*
It uses a precalculated adjacency list instead of iterating every atom to get its "neighbors" during BFS.

*Before*
```
Init bond distances for molecule: 2BG9
Init bond distances took: 120280ms
```

*After*
```
Init bond distances for molecule: 2BG9
Init bond distances took: 1898ms
```
